### PR TITLE
feat: add logout functionality

### DIFF
--- a/frontend/src/ChessCoachApp.ts
+++ b/frontend/src/ChessCoachApp.ts
@@ -481,6 +481,20 @@ export class ChessCoachApp extends LitElement {
     }
   }
 
+  private logout() {
+    const videoCall = this.querySelector('video-call') as any;
+    videoCall?.disconnect?.();
+    this.gameService.disconnect();
+    this.game.reset();
+    this.gameId = '';
+    this.playerId = '';
+    this.isCoach = false;
+    this.gameStatus = 'disconnected';
+    this.position = 'start';
+    this.playerColor = null;
+    this.updateBoardPosition();
+  }
+
   private flipBoard() {
     const board = this.querySelector('chess-board');
     if (board) {
@@ -610,27 +624,34 @@ export class ChessCoachApp extends LitElement {
         <div class="controls-panel">
           <h3 style="margin-top: 0;">Game Controls</h3>
           <div class="controls-row">
-            <button 
+            <button
               class="btn"
-              @click=${this.createGame} 
+              @click=${this.createGame}
               ?disabled=${this.gameStatus !== 'disconnected'}
             >
               🎯 Create Game (Coach)
             </button>
-            <input 
+            <input
               class="input-field"
-              type="text" 
-              placeholder="Enter Game ID" 
+              type="text"
+              placeholder="Enter Game ID"
               .value=${this.gameId}
               @input=${(e: any) => this.gameId = e.target.value}
               ?disabled=${this.gameStatus !== 'disconnected'}
             />
-            <button 
+            <button
               class="btn btn-secondary"
-              @click=${this.joinGame} 
+              @click=${this.joinGame}
               ?disabled=${this.gameStatus !== 'disconnected' || !this.gameId}
             >
               🎓 Join Game (Student)
+            </button>
+            <button
+              class="btn btn-secondary"
+              @click=${this.logout}
+              ?disabled=${this.gameStatus === 'disconnected'}
+            >
+              🚪 Logout
             </button>
           </div>
         </div>

--- a/frontend/src/components/video-call.ts
+++ b/frontend/src/components/video-call.ts
@@ -6,6 +6,8 @@ export class VideoCall extends LitElement {
   /** Room name passed to the Jitsi iframe */
   @property({ type: String }) room = 'chess-default';
 
+  private api: any = null;
+
   static styles = css`
     #jitsi-container {
       width: 100%;
@@ -26,9 +28,20 @@ export class VideoCall extends LitElement {
     script.src = 'https://meet.jit.si/external_api.js';
     script.onload = () => {
       // @ts-ignore – Jitsi attaches itself to window
-      new JitsiMeetExternalAPI(domain, options);
+      this.api = new JitsiMeetExternalAPI(domain, options);
     };
     document.head.appendChild(script);
+  }
+
+  disconnect() {
+    if (this.api) {
+      this.api.dispose();
+      this.api = null;
+    }
+    const container = this.renderRoot.querySelector('#jitsi-container');
+    if (container) {
+      container.innerHTML = '';
+    }
   }
 
   render() {


### PR DESCRIPTION
## Summary
- allow video calls to be disposed when leaving a session
- add logout button and game reset logic in ChessCoachApp

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688f3ca475b88325b6f5aa42416a4698