### PR TITLE
fix: Implement proper game exit functionality to prevent auto-rejoin

### DIFF
--- a/backend/src/main/java/com/chesscoach/controller/GameController.java
+++ b/backend/src/main/java/com/chesscoach/controller/GameController.java
@@ -73,6 +73,16 @@ public class GameController {
         }
     }
 
+    @PostMapping("/{gameId}/leave")
+    public ResponseEntity<?> leaveGame(@PathVariable String gameId, @RequestBody LeaveGameRequest request) {
+        try {
+            gameService.leaveGame(gameId, request.getUserId());
+            return ResponseEntity.ok(Map.of("message", "Successfully left the game"));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
     public static class CreateGameRequest {
         private String hostId;
         private String colorPreference = "random"; // default to random
@@ -124,6 +134,18 @@ public class GameController {
 
         public void setGuestId(String guestId) {
             this.guestId = guestId;
+        }
+    }
+
+    public static class LeaveGameRequest {
+        private Long userId;
+
+        public Long getUserId() {
+            return userId;
+        }
+
+        public void setUserId(Long userId) {
+            this.userId = userId;
         }
     }
 }

--- a/backend/src/main/java/com/chesscoach/entity/Game.java
+++ b/backend/src/main/java/com/chesscoach/entity/Game.java
@@ -57,7 +57,7 @@ public class Game {
     private String result;
     
     public enum GameStatus {
-        WAITING_FOR_GUEST, ACTIVE, PAUSED, ENDED
+        WAITING_FOR_GUEST, ACTIVE, PAUSED, ENDED, ABANDONED
     }
     
     public enum PlayerColor {
@@ -101,6 +101,12 @@ public class Game {
     public void endGame(String result) {
         this.status = GameStatus.ENDED;
         this.result = result;
+        this.endedAt = LocalDateTime.now();
+    }
+
+    public void abandonGame() {
+        this.status = GameStatus.ABANDONED;
+        this.result = "abandoned";
         this.endedAt = LocalDateTime.now();
     }
     

--- a/frontend/src/hooks/useGameState.ts
+++ b/frontend/src/hooks/useGameState.ts
@@ -317,9 +317,14 @@ export const useGameState = (authService: AuthService, currentUser: User | null)
 
   const exitGame = async () => {
     try {
+      // Notify backend that user is leaving the game
+      if (gameState.gameId && gameState.playerId) {
+        await gameServiceRef.current.leaveGame(gameState.gameId, gameState.playerId);
+      }
+
       // Disconnect from WebSocket
       gameServiceRef.current.disconnect();
-      
+
       // Reset game state
       setGameState(prev => ({
         ...prev,
@@ -332,10 +337,10 @@ export const useGameState = (authService: AuthService, currentUser: User | null)
         playerColor: null,
         moveHistory: []
       }));
-      
+
       // Reset chess engine
       gameRef.current = new Chess();
-      
+
     } catch (error) {
       console.error('Error exiting game:', error);
     }

--- a/frontend/src/services/game-service.ts
+++ b/frontend/src/services/game-service.ts
@@ -271,17 +271,32 @@ export class GameService {
 
   async getGameState(gameId: string): Promise<GameState> {
     const headers = this.authService ? this.authService.getAuthHeaders() : { 'Content-Type': 'application/json' };
-    
+
     const response = await fetch(`${this.baseUrl}/api/games/${gameId}`, {
       headers
     });
-    
+
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: 'Failed to get game state' }));
       throw new Error(error.error || 'Failed to get game state');
     }
 
     return response.json();
+  }
+
+  async leaveGame(gameId: string, userId: string): Promise<void> {
+    const headers = this.authService ? this.authService.getAuthHeaders() : { 'Content-Type': 'application/json' };
+
+    const response = await fetch(`${this.baseUrl}/api/games/${gameId}/leave`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ userId: parseInt(userId) })
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: 'Failed to leave game' }));
+      throw new Error(error.error || 'Failed to leave game');
+    }
   }
 
   setGameUpdateListener(callback: (message: GameMessage) => void): void {


### PR DESCRIPTION
## Summary
- Fix users being automatically reconnected to games they had exited
- Add proper backend notification when users leave games  
- Update game status to ABANDONED and user presence to ONLINE on exit

## Root Cause
When users clicked "Exit Game", only client-side cleanup occurred. The backend was never notified, so:
- Game remained in ACTIVE status in database
- User presence stayed as IN_GAME  
- `getCurrentGameForUser` kept finding the "active" game and auto-reconnecting users

## Changes Made

### Backend
- **Game.java**: Add `ABANDONED` status to GameStatus enum + `abandonGame()` method
- **GameService.java**: Add `leaveGame()` method to mark games abandoned and update user presence  
- **GameController.java**: Add `POST /api/games/{gameId}/leave` endpoint

### Frontend  
- **game-service.ts**: Add `leaveGame()` method to call backend API
- **useGameState.ts**: Update `exitGame()` to notify backend before disconnect

## Test Plan
- [x] Backend compiles successfully 
- [x] Frontend TypeScript checks pass
- [x] Application builds without errors
- [ ] Manual testing: Create game → Exit → Refresh page → Verify staying in lobby
- [ ] Database verification: Game status = ABANDONED, User presence = ONLINE

🤖 Generated with [Claude Code](https://claude.ai/code)